### PR TITLE
Ignore asset files starting with dot

### DIFF
--- a/.github/workflows/bats.yml
+++ b/.github/workflows/bats.yml
@@ -1,0 +1,20 @@
+name: Bats
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  unit-test:
+    runs-on: ubuntu-latest
+    name: Bats
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: install bats
+      run: |
+        git clone --depth=1 https://github.com/sstephenson/bats.git
+
+    - name: run tests
+      run: bats/bin/bats ./tests.bat

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -23,6 +23,7 @@ exec 1>&2
 git diff --cached --name-only --diff-filter=A -z $against -- "$ASSETS_DIR" | while read -d $'\0' f; do
 	ext="${f##*.}"
 	base="${f%.*}"
+	filename="$(basename "$f")"
 
 	if [ "$ext" = "meta" ]; then
 		if [ $(git ls-files --cached -- "$base" | wc -l) = 0 ]; then
@@ -35,7 +36,7 @@ Please add \`$base' to git as well.
 EOF
 			exit 1
 		fi
-	else
+	elif [ "${filename##.*}" != '' ]; then
 		p="$f"
 		while [ "$p" != "$ASSETS_DIR" ]; do
 			if [ $(git ls-files --cached -- "$p.meta" | wc -l) = 0 ]; then

--- a/tests.bat
+++ b/tests.bat
@@ -1,0 +1,34 @@
+#!/usr/bin/env bats
+
+PRE_COMMIT="$BATS_TEST_DIRNAME/scripts/pre-commit"
+
+setup() {
+  git init repo >&2
+  cd repo
+  mkdir Assets
+}
+
+teardown() {
+  cd ..
+  rm -rf repo
+}
+
+@test "ensuring .meta is commit" {
+  touch Assets/assets
+  git add Assets/assets
+  run "$PRE_COMMIT"
+  [ "$status" -eq 1 ]
+  [ "${lines[0]}" = "Error: Missing meta file." ]
+
+  touch Assets/assets.meta
+  git add Assets/assets.meta
+  run "$PRE_COMMIT"
+  [ "$status" -eq 0 ]
+}
+
+@test "ignoring assets file which starts with dot" {
+  touch Assets/.assets
+  git add --force Assets/.assets
+  run "$PRE_COMMIT"
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
Unity does not create meta for files starting with dot.

Closes #7