### PR TITLE
fix: ignore git diff renames

### DIFF
--- a/.github/workflows/bats.yml
+++ b/.github/workflows/bats.yml
@@ -14,7 +14,7 @@ jobs:
 
     - name: install bats
       run: |
-        git clone --depth=1 https://github.com/sstephenson/bats.git
+        git clone --depth=1 https://github.com/bats-core/bats-core.git
 
     - name: run tests
-      run: bats/bin/bats ./tests.bat
+      run: bats-core/bin/bats ./tests.bat

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -20,7 +20,7 @@ fi
 # Redirect output to stderr.
 exec 1>&2
 
-git diff --cached --name-only --diff-filter=A -z $against -- "$ASSETS_DIR" | while read -d $'\0' f; do
+git -c diff.renames=false diff --cached --name-only --diff-filter=A -z $against -- "$ASSETS_DIR" | while read -d $'\0' f; do
 	ext="${f##*.}"
 	base="${f%.*}"
 	filename="$(basename "$f")"
@@ -59,18 +59,18 @@ if [ "$ret" != 0 ]; then
 	exit "$ret"
 fi
 
-git diff --cached --name-only --diff-filter=D -z $against -- "$ASSETS_DIR" | while read -d $'\0' f; do
+git -c diff.renames=false diff --cached --name-only --diff-filter=D -z $against -- "$ASSETS_DIR" | while read -d $'\0' f; do
 	ext="${f##*.}"
 	base="${f%.*}"
 
 	if [ "$ext" = "meta" ]; then
 		if [ $(git ls-files --cached -- "$base" | wc -l) != 0 ]; then
 			cat <<EOF
-Error: Redudant meta file.
+Error: Missing meta file.
 
 Meta file \`$f' is removed, but \`$base' is still in the git index.
 
-Please remove \`$base' from git as well.
+Please revert the beta file or remove the asset file.
 EOF
 			exit 1
 		fi
@@ -79,7 +79,7 @@ EOF
 		while [ "$p" != "$ASSETS_DIR" ]; do
 			if [ $(git ls-files --cached -- "$p" | wc -l) = 0 ] && [ $(git ls-files --cached -- "$p.meta" | wc -l) != 0 ]; then
 				cat <<EOF
-Error: Missing meta file.
+Error: Redudant meta file.
 
 Asset \`$f' is removed, but \`$p.meta' is still in the git index.
 

--- a/tests.bat
+++ b/tests.bat
@@ -5,6 +5,8 @@ PRE_COMMIT="$BATS_TEST_DIRNAME/scripts/pre-commit"
 setup() {
   git init repo >&2
   cd repo
+  git config user.email "bats@ci"
+  git config user.name "bats"
   mkdir Assets
 }
 
@@ -17,18 +19,31 @@ teardown() {
   touch Assets/assets
   git add Assets/assets
   run "$PRE_COMMIT"
+  echo "$output"
   [ "$status" -eq 1 ]
   [ "${lines[0]}" = "Error: Missing meta file." ]
 
   touch Assets/assets.meta
   git add Assets/assets.meta
-  run "$PRE_COMMIT"
-  [ "$status" -eq 0 ]
+  "$PRE_COMMIT"
 }
 
 @test "ignoring assets file which starts with dot" {
   touch Assets/.assets
   git add --force Assets/.assets
+  "$PRE_COMMIT"
+}
+
+@test "renaming directory" {
+  mkdir Assets/dir
+  touch Assets/dir/.gitkeep
+  touch Assets/dir.meta
+  git add --force --all
+  git commit -n -m 'add Assets/dir'
+  mv Assets/dir Assets/dir-new
+  git add --force --all
   run "$PRE_COMMIT"
-  [ "$status" -eq 0 ]
+  echo "$output"
+  [ "$status" -eq 1 ]
+  [ "${lines[0]}" = "Error: Redudant meta file." ]
 }


### PR DESCRIPTION
The `pre-commit` script uses following command to scan added and deleted
files:

```
git diff --cached --name-only --diff-filter=A -z $against -- "$ASSETS_DIR"
git diff --cached --name-only --diff-filter=D -z $against -- "$ASSETS_DIR"
```

Since a version, git detects renames by default and will not list
renames in filter A and D.

There's a command line parameter `--no-renames`, but I use the config
option instead which is compatible with old git versions:

```
git -c diff.renames=false diff --cached --name-only --diff-filter=A -z $against -- "$ASSETS_DIR"
git -c diff.renames=false diff --cached --name-only --diff-filter=D -z $against -- "$ASSETS_DIR"
```

Closes https://github.com/doitian/unity-git-hooks/issues/9
